### PR TITLE
Add catboost & lightgbm support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,45 @@
+name: Build wheel & Run User Scenarios
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up python 3.9
+        id: setup-python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+            python -m pip install --upgrade pip
+            pip install -r requirements.txt
+            pip install -r requirements-dev.txt
+            pip install flit
+
+      - name: Build package
+        run: flit build
+
+      - name: Install package
+        run: pip install dist/*.whl
+
+      - name: Run user examples
+        run: |
+          pip install scikit-learn xgboost lightgbm catboost
+
+          cd examples
+
+          python sklearn_examples/skl_clf.py
+          python catboost_example.py
+          python xgboost_example.py
+          python lightgbm_example.py

--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,5 @@ dmypy.json
 /tests/project/
 
 node_modules/
+
+**/catboost_info/

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Currently, we support the following models:
 
 - `sklearn`
 - `xgboost`
+- `catboost`
+- `lightgbm`
 
 ## RoadMap
 

--- a/deployme/contrib/entrypoint.py
+++ b/deployme/contrib/entrypoint.py
@@ -24,7 +24,7 @@ log = logging.getLogger(__name__)
 
 def cook(
     *,
-    model: Estimator,
+    model,
     strategy: Union[Strategy, str] = Strategy.DOCKER,
     backend: Optional[Union[str, PathLike]] = None,
     tag: Optional[str] = None,

--- a/deployme/contrib/supported.py
+++ b/deployme/contrib/supported.py
@@ -2,10 +2,8 @@
 
 from enum import Enum
 
-from sklearn.base import BaseEstimator
-from sklearn.pipeline import Pipeline
-
 from deployme.utils.types import Estimator
+from deployme.utils.utils import parse_cls_name
 
 
 class ModelType(str, Enum):
@@ -13,17 +11,22 @@ class ModelType(str, Enum):
     Model type.
     """
 
-    # LightAutoML model
-    LAMA = "LAMA"
-
-    # Sklearn pipeline, such as `Pipeline`
-    SKLEARN_PIPE = "SKLEARN_PIPELINE"
-
     # Sklearn model, such as `LogisticRegression`
-    SKLEARN_MODEL = "SKLEARN_MODEL"
+    SKLEARN = "sklearn"
 
-    # In the future, we could add more types,
-    # such as `XGBoost` or `CatBoost`
+    # CatBoost model, such as `CatBoostClassifier`
+    CATBOOST = "catboost"
+
+    # XGB model, such as `XGBClassifier`
+    XGBOOST = "xgboost"
+
+    # LightGBM model, such as `LGBMClassifier`
+    LGBM = "lightgbm"
+
+    # LightAutoML model
+    LAMA = "lightautoml"
+
+    # In the future, we could add more types.
 
     @classmethod
     def from_model(cls, model: Estimator):
@@ -37,14 +40,19 @@ class ModelType(str, Enum):
             Model type.
         """
 
-        if "lightautoml" in str(type(model)):
-            return cls.LAMA
+        parts = parse_cls_name(model).split(".")
 
-        if isinstance(model, Pipeline):
-            return cls.SKLEARN_PIPE
+        mt = next(
+            (
+                ModelType(p)
+                for p in parts
+                if p in ModelType.__members__.values()
+            ),
+            None,
+        )
 
-        if isinstance(model, BaseEstimator):
-            return cls.SKLEARN_MODEL
+        if mt:
+            return mt
 
         raise ValueError(f"Model `{model}` now isn't supported")
 
@@ -59,3 +67,7 @@ class Strategy(str, Enum):
 
     # In the future, we can add other strategies
     # like deploy to AWS Lambda, etc.
+
+
+if __name__ == "__main__":
+    print(ModelType["LAMA"])

--- a/deployme/cookie/templates/ml/_default.py
+++ b/deployme/cookie/templates/ml/_default.py
@@ -1,7 +1,12 @@
 """Module that contains Scikit-learn model method's wrappers."""
 from deployme.contrib.supported import ModelType
 
-USED_FOR = [ModelType.SKLEARN_MODEL, ModelType.SKLEARN_PIPE]
+USED_FOR = [
+    ModelType.SKLEARN,
+    ModelType.XGBOOST,
+    ModelType.CATBOOST,
+    ModelType.LGBM,
+]
 
 
 def predict(model, data) -> list:

--- a/deployme/utils/utils.py
+++ b/deployme/utils/utils.py
@@ -1,6 +1,11 @@
 """Utils module."""
 import inspect
+import re
 from typing import Callable
+
+CLS_REGEX = re.compile(
+    r"<class\s'(.*?)'>", re.IGNORECASE | re.MULTILINE | re.DOTALL
+)
 
 
 def drop_unnecessary_kwargs(func: Callable, kwargs: dict) -> dict:
@@ -20,3 +25,11 @@ def is_package_installed(name: str) -> bool:
         return True
     except ImportError:
         return False
+
+
+def parse_cls_name(obj) -> str:
+    """Parse class name."""
+    match_obj = CLS_REGEX.match(str(type(obj)))
+    if match_obj:
+        return match_obj.group(1)
+    return str(type(obj))

--- a/docs/source/tutorial/features/001_first.ipynb
+++ b/docs/source/tutorial/features/001_first.ipynb
@@ -1,111 +1,178 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "\n\n# 1. Lightweight and versatile\n\nDeployMe is written entirely in Python with few dependencies.\nThis means that once you get interested in DeployMe, we can quickly move to a practical example.\n\n\n## Simple Sklearn Local Example\n\nDeployMe provides a simple interface to create project and deploy a model.\n\n- :func:`deployme.contrib.entrypoint.cook` is a function that takes a model and a strategy and deploys it.\n\nIn this example, we simply create a project with scikit-learn.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Firstly, import :mod:`deployme`.\n\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "collapsed": false
-      },
-      "outputs": [],
-      "source": [
-        "import deployme"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Import :class:`sklearn.ensemble.RandomForestClassifier` as classifier\nand :mod:`sklearn.datasets` to load the iris dataset.\n\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "collapsed": false
-      },
-      "outputs": [],
-      "source": [
-        "from sklearn.datasets import load_iris\nfrom sklearn.ensemble import RandomForestClassifier"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Let's load dataset and create and train a simple model.\n\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "collapsed": false
-      },
-      "outputs": [],
-      "source": [
-        "X, y = load_iris(return_X_y=True)\nclf = RandomForestClassifier()\nclf.fit(X, y)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Now, we can deploy the model with :func:`deployme.contrib.entrypoint.cook`.\nMain arguments are ``model`` and ``strategy``.\n\nThe strategy can be either `local` or `docker`.\nThe `local` strategy will deploy the model locally.\nThe `docker` strategy will deploy the model in a docker container.\nThe :func:`deployme.contrib.entrypoint.cook` function will return a bool or container name.\n\nNow we make only a project without running it.\nAfter calling the :func:`deployme.contrib.entrypoint.cook` function\nYou can see `build` folder in the current directory.\n\nIt contains:\n\n- `Dockerfile` - Dockerfile for the model\n\n- `requirements.txt` - requirements for the model\n\n- `models` directory - directory with the dumped model\n\n- `data` directory - directory with the example for the model\n\n- `server.py` - main file for the model\n\n\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "collapsed": false
-      },
-      "outputs": [],
-      "source": [
-        "deployme.contrib.cook(strategy=\"local\", model=clf)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Let's see on :func:`deployme.contrib.entrypoint.cook` signature.\nThis function accepts a lot of parameters, but we see only the most important ones.\n\n- `model` - model to deploy\n- `strategy` - strategy to use\n- `backend` - backend to use\n- `need_run` - run service after build or not\n- `scan_path` - path to scan for requirements\n- `silent` - silent mode\n- `verbose` - verbose mode\n\nModel parameter is the most important one.\nIt can be any model that implements the `predict` and other methods.\n\n<div class=\"alert alert-info\"><h4>Note</h4><p>The model must be picklable.</p></div>\n\n<div class=\"alert alert-info\"><h4>Note</h4><p>Now is supported `sklearn`, `xgboost`.</p></div>\n\nStrategy parameter determines the strategy to use.\n\nBackend parameter determines the backend to use.\nNow is implemented :mod:`sanic` and :mod:`flask` backends.\n\n"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.9.13"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "\n",
+    "# 1. Lightweight and versatile\n",
+    "\n",
+    "DeployMe is written entirely in Python with few dependencies.\n",
+    "This means that once you get interested in DeployMe, we can quickly move to a practical example.\n",
+    "\n",
+    "\n",
+    "## Simple Sklearn Local Example\n",
+    "\n",
+    "DeployMe provides a simple interface to create project and deploy a model.\n",
+    "\n",
+    "- :func:`deployme.contrib.entrypoint.cook` is a function that takes a model and a strategy and deploys it.\n",
+    "\n",
+    "In this example, we simply create a project with scikit-learn.\n"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Firstly, import :mod:`deployme`.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import deployme"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Import :class:`sklearn.ensemble.RandomForestClassifier` as classifier\n",
+    "and :mod:`sklearn.datasets` to load the iris dataset.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from sklearn.datasets import load_iris\n",
+    "from sklearn.ensemble import RandomForestClassifier"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's load dataset and create and train a simple model.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "X, y = load_iris(return_X_y=True)\n",
+    "clf = RandomForestClassifier()\n",
+    "clf.fit(X, y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, we can deploy the model with :func:`deployme.contrib.entrypoint.cook`.\n",
+    "Main arguments are ``model`` and ``strategy``.\n",
+    "\n",
+    "The strategy can be either `local` or `docker`.\n",
+    "The `local` strategy will deploy the model locally.\n",
+    "The `docker` strategy will deploy the model in a docker container.\n",
+    "The :func:`deployme.contrib.entrypoint.cook` function will return a bool or container name.\n",
+    "\n",
+    "Now we make only a project without running it.\n",
+    "After calling the :func:`deployme.contrib.entrypoint.cook` function\n",
+    "You can see `build` folder in the current directory.\n",
+    "\n",
+    "It contains:\n",
+    "\n",
+    "- `Dockerfile` - Dockerfile for the model\n",
+    "\n",
+    "- `requirements.txt` - requirements for the model\n",
+    "\n",
+    "- `models` directory - directory with the dumped model\n",
+    "\n",
+    "- `data` directory - directory with the example for the model\n",
+    "\n",
+    "- `server.py` - main file for the model\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "deployme.contrib.cook(strategy=\"local\", model=clf)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's see on :func:`deployme.contrib.entrypoint.cook` signature.\n",
+    "This function accepts a lot of parameters, but we see only the most important ones.\n",
+    "\n",
+    "- `model` - model to deploy\n",
+    "- `strategy` - strategy to use\n",
+    "- `backend` - backend to use\n",
+    "- `need_run` - run service after build or not\n",
+    "- `scan_path` - path to scan for requirements\n",
+    "- `silent` - silent mode\n",
+    "- `verbose` - verbose mode\n",
+    "\n",
+    "Model parameter is the most important one.\n",
+    "It can be any model that implements the `predict` and other methods.\n",
+    "\n",
+    "<div class=\"alert alert-info\"><h4>Note</h4><p>The model must be picklable.</p></div>\n",
+    "\n",
+    "<div class=\"alert alert-info\"><h4>Note</h4><p>Now is supported `sklearn`, `xgboost`.</p></div>\n",
+    "\n",
+    "Strategy parameter determines the strategy to use.\n",
+    "\n",
+    "Backend parameter determines the backend to use.\n",
+    "Now is implemented :mod:`sanic` and :mod:`flask` backends.\n",
+    "\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/docs/source/tutorial/features/001_first.py
+++ b/docs/source/tutorial/features/001_first.py
@@ -87,7 +87,7 @@ deployme.contrib.cook(strategy="local", model=clf)
 #     The model must be picklable.
 #
 # .. note::
-#     Now is supported `sklearn`, `xgboost`.
+#     Now is supported `sklearn`, `xgboost`, `catboost`, `lightgbm` models.
 #
 # Strategy parameter determines the strategy to use.
 #

--- a/docs/source/tutorial/features/001_first.rst
+++ b/docs/source/tutorial/features/001_first.rst
@@ -176,7 +176,7 @@ It can be any model that implements the `predict` and other methods.
     The model must be picklable.
 
 .. note::
-    Now is supported `sklearn`, `xgboost`.
+    Now is supported `sklearn`, `xgboost`, `catboost`, `lightgbm` models.
 
 Strategy parameter determines the strategy to use.
 

--- a/docs/source/tutorial/features/002_docker.ipynb
+++ b/docs/source/tutorial/features/002_docker.ipynb
@@ -1,140 +1,198 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "\n\n# 2. Deploy with Docker\n\nIn this example, we deploy the model with Docker.\nFor this example you need to install Docker, see [Docker](https://docs.docker.com/get-docker/)\nand XGBoost, see [XGBoost](https://xgboost.readthedocs.io/en/latest/build.html).\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Firstly, import :mod:`deployme`.\n\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "collapsed": false
-      },
-      "outputs": [],
-      "source": [
-        "import deployme"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Import :class:`xgboost.XGBClassifier` as classifier\nand :mod:`sklearn.datasets` to load the iris dataset.\n\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "collapsed": false
-      },
-      "outputs": [],
-      "source": [
-        "from sklearn.datasets import load_iris\nfrom xgboost import XGBClassifier"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Let's load dataset and create and train a simple model.\n\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "collapsed": false
-      },
-      "outputs": [],
-      "source": [
-        "X, y = load_iris(return_X_y=True)\nclf = XGBClassifier()\nclf.fit(X, y)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Now, we can deploy the model to `docker` with :func:`deployme.contrib.entrypoint.cook`.\n\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "collapsed": false
-      },
-      "outputs": [],
-      "source": [
-        "deployme.contrib.cook(\n    model=clf,\n    strategy=\"docker\",\n    tag=\"deployme-xgboost\",\n    port=5000,\n    need_run=True,\n    silent=True,\n    verbose=False,\n)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Let's see on passed parameters.\n\n- `model` - model to deploy - `clf` (XGBoost model)\n\n- `strategy` - strategy to use - `docker`\n\n- `tag` - tag for the docker image - `deployme-xgboost`\n\n- `port` - port for the docker container - `8000`\n\n- `backend` - backend to use - `sanic`, see [Sanic](https://sanicframework.org/)\n\n- `need_run` - run service after build or not - `True` (only create container)\n\n- `silent` - silent mode - `True`, non-blocking mode\n\n- `verbose` - verbose mode - `True`, print DEBUG logs\n\nAfter calling the :func:`deployme.contrib.entrypoint.cook` function\nYou can see `build` folder in the current directory.\nAnd you can see the docker image and container with name `deployme-xgboost`.\n\nNow we can send a request to the model.\nFor this example, we use requests, see [Requests](https://requests.readthedocs.io/en/master/).\nYou can use any other tool, for example [Postman](https://www.postman.com/).\nFirstly, import requests.\n\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "collapsed": false
-      },
-      "outputs": [],
-      "source": [
-        "import time\n\nimport requests"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Let's sleep for 5 seconds and check the response.\n\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "collapsed": false
-      },
-      "outputs": [],
-      "source": [
-        "time.sleep(5)\n\nresponse = requests.post(\n    \"http://localhost:5000/predict\",\n    json={\"data\": X.tolist()},\n)\n\nprint(response.json())"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.9.13"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "\n",
+    "# 2. Deploy with Docker\n",
+    "\n",
+    "In this example, we deploy the model with Docker.\n",
+    "For this example you need to install Docker, see [Docker](https://docs.docker.com/get-docker/)\n",
+    "and XGBoost, see [XGBoost](https://xgboost.readthedocs.io/en/latest/build.html).\n"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Firstly, import :mod:`deployme`.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import deployme"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Import :class:`xgboost.XGBClassifier` as classifier\n",
+    "and :mod:`sklearn.datasets` to load the iris dataset.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from sklearn.datasets import load_iris\n",
+    "from xgboost import XGBClassifier"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's load dataset and create and train a simple model.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "X, y = load_iris(return_X_y=True)\n",
+    "clf = XGBClassifier()\n",
+    "clf.fit(X, y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, we can deploy the model to `docker` with :func:`deployme.contrib.entrypoint.cook`.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "deployme.contrib.cook(\n",
+    "    model=clf,\n",
+    "    strategy=\"docker\",\n",
+    "    tag=\"deployme-xgboost\",\n",
+    "    port=5000,\n",
+    "    need_run=True,\n",
+    "    silent=True,\n",
+    "    verbose=False,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's see on passed parameters.\n",
+    "\n",
+    "- `model` - model to deploy - `clf` (XGBoost model)\n",
+    "\n",
+    "- `strategy` - strategy to use - `docker`\n",
+    "\n",
+    "- `tag` - tag for the docker image - `deployme-xgboost`\n",
+    "\n",
+    "- `port` - port for the docker container - `8000`\n",
+    "\n",
+    "- `backend` - backend to use - `sanic`, see [Sanic](https://sanicframework.org/)\n",
+    "\n",
+    "- `need_run` - run service after build or not - `True` (only create container)\n",
+    "\n",
+    "- `silent` - silent mode - `True`, non-blocking mode\n",
+    "\n",
+    "- `verbose` - verbose mode - `True`, print DEBUG logs\n",
+    "\n",
+    "After calling the :func:`deployme.contrib.entrypoint.cook` function\n",
+    "You can see `build` folder in the current directory.\n",
+    "And you can see the docker image and container with name `deployme-xgboost`.\n",
+    "\n",
+    "Now we can send a request to the model.\n",
+    "For this example, we use requests, see [Requests](https://requests.readthedocs.io/en/master/).\n",
+    "You can use any other tool, for example [Postman](https://www.postman.com/).\n",
+    "Firstly, import requests.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "\n",
+    "import requests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's sleep for 5 seconds and check the response.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "time.sleep(5)\n",
+    "\n",
+    "response = requests.post(\n",
+    "    \"http://localhost:5000/predict\",\n",
+    "    json={\"data\": X.tolist()},\n",
+    ")\n",
+    "\n",
+    "print(response.json())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/examples/catboost_example.py
+++ b/examples/catboost_example.py
@@ -1,6 +1,6 @@
+from catboost import CatBoostClassifier
 from sklearn.datasets import load_iris
 from sklearn.model_selection import train_test_split
-from xgboost import XGBClassifier
 
 from deployme import cook
 
@@ -12,16 +12,16 @@ def main():
         data["data"], data["target"], test_size=0.2
     )
     # create model instance
-    bst = XGBClassifier(
-        n_estimators=2,
-        max_depth=2,
+    cat = CatBoostClassifier(
+        iterations=2,
+        depth=2,
         learning_rate=1,
-        objective="binary:logistic",
+        loss_function="MultiClass",
     )
     # fit model
-    bst.fit(X_train, y_train)
+    cat.fit(X_train, y_train)
 
-    cook(strategy="local", model=bst, verbose=True)
+    cook(strategy="local", model=cat, verbose=True)
 
 
 if __name__ == "__main__":

--- a/examples/lightgbm_example.py
+++ b/examples/lightgbm_example.py
@@ -1,6 +1,6 @@
+from lightgbm import LGBMClassifier
 from sklearn.datasets import load_iris
 from sklearn.model_selection import train_test_split
-from xgboost import XGBClassifier
 
 from deployme import cook
 
@@ -12,16 +12,15 @@ def main():
         data["data"], data["target"], test_size=0.2
     )
     # create model instance
-    bst = XGBClassifier(
+    lgbm = LGBMClassifier(
         n_estimators=2,
         max_depth=2,
         learning_rate=1,
-        objective="binary:logistic",
     )
     # fit model
-    bst.fit(X_train, y_train)
+    lgbm.fit(X_train, y_train)
 
-    cook(strategy="local", model=bst, verbose=True)
+    cook(strategy="local", model=lgbm, verbose=True)
 
 
 if __name__ == "__main__":

--- a/examples/sklearn_examples/skl_clf.py
+++ b/examples/sklearn_examples/skl_clf.py
@@ -14,7 +14,7 @@ def main():
     clf = RandomForestClassifier()
     clf.fit(X_train, y_train)
 
-    cook(strategy="docker", model=clf, port=5010, verbose=True)
+    cook(strategy="docker", model=clf, verbose=True)
 
 
 if __name__ == "__main__":

--- a/tests/contrib/project_builder/test_full_build.py
+++ b/tests/contrib/project_builder/test_full_build.py
@@ -1,3 +1,4 @@
+import logging
 import pickle
 from pathlib import Path
 from unittest.mock import patch
@@ -39,6 +40,7 @@ def test_full_build(
     models = [RandomForestClassifier(), LogisticRegression()]
     models_names = ["rf", "lr"]
     template_path = Path(backend_path).joinpath("server.py")
+    logging.disable(logging.CRITICAL)
 
     mocker = DefaultIOMock(to_forward=[template_path])
     with mocker:
@@ -49,6 +51,7 @@ def test_full_build(
                     """
 sanic==20.12.2"""
                 )
+                return {"sanic": "20.12.2"}
 
         with patch(
             "deployme.contrib.project_builder.make_requirements_txt",
@@ -79,3 +82,5 @@ sanic==20.12.2"""
 """
 
     assert expected.replace(" ", "") in mocker.fs_tree.replace(" ", "")
+
+    logging.disable(logging.NOTSET)

--- a/tests/contrib/validator/test_validate_ret_model.py
+++ b/tests/contrib/validator/test_validate_ret_model.py
@@ -11,10 +11,10 @@ from deployme.contrib.validator import validate_ret_model
 @given(model=sampled_from([RandomForestClassifier(), LogisticRegression()]))
 def test_validate_ret_model_valid(model):
     """Ensures that valid model is returned."""
-    assert validate_ret_model(model) == ModelType.SKLEARN_MODEL
+    assert validate_ret_model(model) == ModelType.SKLEARN
 
 
 @given(model=sampled_from([Pipeline(...)]))
 def test_validate_ret_model_valid_pipeline(model):
     """Ensures that valid pipeline is returned."""
-    assert validate_ret_model(model) == ModelType.SKLEARN_PIPE
+    assert validate_ret_model(model) == ModelType.SKLEARN

--- a/tests/functional/test_catboost.py
+++ b/tests/functional/test_catboost.py
@@ -1,0 +1,37 @@
+import logging
+import shutil
+from pathlib import Path
+
+import pytest
+from sklearn.datasets import load_iris
+from sklearn.model_selection import train_test_split
+
+from deployme import cook
+from deployme.utils.utils import is_package_installed
+
+log = logging.getLogger(__name__)
+
+
+@pytest.mark.skipif(
+    not is_package_installed("catboost"), reason="CatBoost is not installed"
+)
+def test_cook_catboost():
+    from catboost import CatBoostClassifier
+
+    data = load_iris()
+    X_train, X_test, y_train, y_test = train_test_split(
+        data["data"], data["target"], test_size=0.2
+    )
+    # create model instance
+    cat = CatBoostClassifier(
+        iterations=2,
+        depth=2,
+        learning_rate=1,
+        loss_function="MultiClass",
+    )
+    # fit model
+    cat.fit(X_train, y_train)
+
+    cook(model=cat, strategy="local", backend="sanic", need_run=False)
+    assert Path("build").exists()
+    shutil.rmtree("build", ignore_errors=True)

--- a/tests/functional/test_lightgbm.py
+++ b/tests/functional/test_lightgbm.py
@@ -1,0 +1,32 @@
+import logging
+import shutil
+from pathlib import Path
+
+import pytest
+from sklearn.datasets import load_iris
+from sklearn.model_selection import train_test_split
+
+from deployme import cook
+from deployme.utils.utils import is_package_installed
+
+log = logging.getLogger(__name__)
+
+
+@pytest.mark.skipif(
+    not is_package_installed("lightgbm"), reason="LightGBM is not installed"
+)
+def test_cook_lightgbm():
+    from lightgbm import LGBMClassifier
+
+    data = load_iris()
+    X_train, X_test, y_train, y_test = train_test_split(
+        data["data"], data["target"], test_size=0.2
+    )
+    # create model instance
+    cat = LGBMClassifier()
+    # fit model
+    cat.fit(X_train, y_train)
+
+    cook(model=cat, strategy="local", backend="sanic", need_run=False)
+    assert Path("build").exists()
+    shutil.rmtree("build", ignore_errors=True)

--- a/tests/functional/test_sklearn.py
+++ b/tests/functional/test_sklearn.py
@@ -41,6 +41,7 @@ log = logging.getLogger(__name__)
     backend=st.sampled_from(list(SUPPORTED_BACKENDS.keys())),
 )
 @settings(deadline=None)
+@pytest.mark.repeat(5)
 def test_cook_classification(model, backend):
     X, y = load_iris(return_X_y=True)
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2)

--- a/tests/utils/test_nb.py
+++ b/tests/utils/test_nb.py
@@ -3,7 +3,11 @@ from pathlib import Path
 import jsonschema
 import nbformat
 import pytest
-from hypothesis import given
+from hypothesis import (
+    HealthCheck,
+    given,
+    settings,
+)
 from hypothesis_jsonschema import from_schema
 
 from deployme.utils.nb import (
@@ -45,6 +49,7 @@ NOTEBOOKS_EXAMPLES_FOLDER = Path(__file__).parent.joinpath("notebooks-examples")
         }
     )
 )
+@settings(suppress_health_check=(HealthCheck.too_slow,))
 def test_get_code_cells_sources_from_notebook(notebook: _Notebook):
     count_of_code_cells = len(
         [

--- a/tests/utils/test_requirements_merger.py
+++ b/tests/utils/test_requirements_merger.py
@@ -17,7 +17,9 @@ from deployme.utils.requirements import (
 
 @given(
     x=st.lists(
-        st.from_regex(r"numpy==[0-9]\.[0-9]\.[0-9]", fullmatch=True), min_size=1
+        st.from_regex(r"numpy==[0-9]\.[0-9]\.[0-9]", fullmatch=True),
+        min_size=1,
+        max_size=5,
     ),
 )
 def test_merge(x):


### PR DESCRIPTION
This PR has added support for `Catboost` & `LightGBM` frameworks, as well as

- The `ModelType` selection logic has been changed, now it is more accurate
- New examples with `CatBoost` & `LightGBM` have been added
- A new workflow for CI has been added, running wheel package builds as well as running minimal user scenarios
- Small tests fixes

CC: @pacifikus 